### PR TITLE
トレーニングメニュー提案機能作成

### DIFF
--- a/app/assets/stylesheets/training_suggestions.scss
+++ b/app/assets/stylesheets/training_suggestions.scss
@@ -1,3 +1,3 @@
-// Place all the styles related to the RunningSuggestions controller here.
+// Place all the styles related to the TrainingSuggestions controller here.
 // They will automatically be included in application.css.
 // You can use Sass (SCSS) here: https://sass-lang.com/

--- a/app/controllers/running_suggestions_controller.rb
+++ b/app/controllers/running_suggestions_controller.rb
@@ -1,4 +1,0 @@
-class RunningSuggestionsController < ApplicationController
-  def new
-  end
-end

--- a/app/controllers/top_pages_controller.rb
+++ b/app/controllers/top_pages_controller.rb
@@ -1,5 +1,6 @@
 class TopPagesController < ApplicationController
   def top
-    @user = @current_user.id
+    @user = current_user.id
+    @training_suggestion = TrainingSuggestion.find_by(user_id: current_user.id)
   end
 end

--- a/app/controllers/training_suggestions_controller.rb
+++ b/app/controllers/training_suggestions_controller.rb
@@ -19,6 +19,21 @@ class TrainingSuggestionsController < ApplicationController
     @training_suggestion = current_user.training_suggestions.find(params[:id])
   end
 
+  def edit
+    @training_suggestion = current_user.training_suggestions.find(params[:id])
+  end
+
+  def update
+    @training_suggestion = current_user.training_suggestions.find(params[:id])
+    if @training_suggestion.update(training_suggestion_params)
+      redirect_to training_suggestion_path(@training_suggestion)
+      flash[:success] = t('.success')
+    else
+      flash.now[:danger] = t('.fail')
+      render :edit
+    end
+  end
+
   private
 
   def training_suggestion_params

--- a/app/controllers/training_suggestions_controller.rb
+++ b/app/controllers/training_suggestions_controller.rb
@@ -1,0 +1,23 @@
+class TrainingSuggestionsController < ApplicationController
+  def new
+    @training_suggestion = TrainingSuggestion.new
+  end
+
+  def create
+    @training_suggestion = current_user.training_suggestions.build(training_suggestion_params)
+    if @training_suggestion.save
+      redirect_to training_suggestions_path
+      flash[:success] = t(".success")
+    else
+      flash.now[:danger] = t(".fail")
+      render :new
+    end
+
+  end
+
+  private
+
+  def training_suggestion_params
+    params.require(:training_suggestion).permit(:training_distance, :intensity)
+  end
+end

--- a/app/controllers/training_suggestions_controller.rb
+++ b/app/controllers/training_suggestions_controller.rb
@@ -6,13 +6,17 @@ class TrainingSuggestionsController < ApplicationController
   def create
     @training_suggestion = current_user.training_suggestions.build(training_suggestion_params)
     if @training_suggestion.save
-      redirect_to training_suggestions_path
+      redirect_to training_suggestion_path(@training_suggestion)
       flash[:success] = t(".success")
     else
       flash.now[:danger] = t(".fail")
       render :new
     end
 
+  end
+
+  def show
+    @training_suggestion = current_user.training_suggestions.find(params[:id])
   end
 
   private

--- a/app/controllers/training_suggestions_controller.rb
+++ b/app/controllers/training_suggestions_controller.rb
@@ -22,6 +22,6 @@ class TrainingSuggestionsController < ApplicationController
   private
 
   def training_suggestion_params
-    params.require(:training_suggestion).permit(:training_distance, :intensity)
+    params.require(:training_suggestion).permit(:running_distance, :intensity)
   end
 end

--- a/app/helpers/running_suggestions_helper.rb
+++ b/app/helpers/running_suggestions_helper.rb
@@ -1,2 +1,0 @@
-module RunningSuggestionsHelper
-end

--- a/app/helpers/training_suggestions_helper.rb
+++ b/app/helpers/training_suggestions_helper.rb
@@ -1,0 +1,2 @@
+module TrainingSuggestionsHelper
+end

--- a/app/models/training_suggestion.rb
+++ b/app/models/training_suggestion.rb
@@ -26,6 +26,7 @@ class TrainingSuggestion < ApplicationRecord
     "#{min}:#{sec} / km"
   end
 
+  # 総ランニング時間の導出
   def pace_time
     time = (1000 / velocity) * self.running_distance  # 総ランニング時間(minを小数で)
     hour = (time / 60).floor.to_i                     # 総ランニング時間(hourだけ)
@@ -34,6 +35,7 @@ class TrainingSuggestion < ApplicationRecord
     "#{hour}:#{min}:#{sec}"
   end
 
+  # 消費カロリーの導出
   def calorie
     time = (1000 / velocity) * self.running_distance                                            # 総ランニング時間(minを小数で)
     mets = self.user.vdot * percent / 3.5                                                       # mets導出

--- a/app/models/training_suggestion.rb
+++ b/app/models/training_suggestion.rb
@@ -1,4 +1,48 @@
 class TrainingSuggestion < ApplicationRecord
   belongs_to :user
   enum intensity: { E: 0, M: 1, T: 2, I: 3, R: 4 }
+
+  def percent
+    case self.intensity.to_f
+    when 0
+      0.66
+    when 1
+      0.815
+    when 2
+      0.875
+    when 3
+      97.5
+    when 4
+      107
+    end
+  end
+
+  def pace
+    vdot = self.user.vdot * percent
+    vel = 29.54 + 5.000663 * vdot - 0.007546 * vdot ** 2
+    time = 1000 / vel
+    min = time.to_i
+    sec = ((time - min) * 60).to_i
+    "#{min}:#{sec} / km"
+  end
+
+  def pace_time
+    vdot = self.user.vdot * percent
+    vel = 29.54 + 5.000663 * vdot - 0.007546 * vdot ** 2
+    time = (1000 / vel) * self.running_distance
+    hour = (time / 60).floor.to_i
+    min = (time - hour * 60).to_i
+    sec = ((time - hour * 60 - min) * 60).to_i
+    "#{hour}:#{min}:#{sec}"
+  end
+
+  def calorie
+    vdot = self.user.vdot * percent
+    vel = 29.54 + 5.000663 * vdot - 0.007546 * vdot ** 2
+    time = (1000 / vel) * self.running_distance
+    mets = vdot / 3.5
+    cal = (self.user.weight.present? ? mets * self.user.weight * time / 60 * 1.05 : nil).to_i
+    "#{cal} kcal"
+  end
+
 end

--- a/app/models/training_suggestion.rb
+++ b/app/models/training_suggestion.rb
@@ -1,3 +1,4 @@
 class TrainingSuggestion < ApplicationRecord
   belongs_to :user
+  enum intensity: { E: 0, M: 1, T: 2, I: 3, R: 4 }
 end

--- a/app/models/training_suggestion.rb
+++ b/app/models/training_suggestion.rb
@@ -5,15 +5,15 @@ class TrainingSuggestion < ApplicationRecord
   # 練習強度(intensity)ごとにランニング時のVO2maxに対する負荷の比率を定義
   def percent
     case self.intensity.to_f
-    when 0
+    when 0  # E
       0.66
-    when 1
+    when 1  # M
       0.815
-    when 2
+    when 2  # T
       0.875
-    when 3
+    when 3  # I
       97.5
-    when 4
+    when 4  # R
       107
     end
   end

--- a/app/models/training_suggestion.rb
+++ b/app/models/training_suggestion.rb
@@ -2,6 +2,7 @@ class TrainingSuggestion < ApplicationRecord
   belongs_to :user
   enum intensity: { E: 0, M: 1, T: 2, I: 3, R: 4 }
 
+  # 練習強度(intensity)ごとにランニング時のVO2maxに対する負荷の比率を定義
   def percent
     case self.intensity.to_f
     when 0
@@ -17,32 +18,33 @@ class TrainingSuggestion < ApplicationRecord
     end
   end
 
+  # 1kmあたりのペース導出
   def pace
-    vdot = self.user.vdot * percent
-    vel = 29.54 + 5.000663 * vdot - 0.007546 * vdot ** 2
-    time = 1000 / vel
-    min = time.to_i
-    sec = ((time - min) * 60).to_i
+    time = 1000 / velocity            # 1kmあたりランニング時間(minを小数で)
+    min = time.floor.to_i             # 1kmあたりランニング時間(minだけ)
+    sec = ((time - min) * 60).to_i    # 1kmあたりランニング時間(secondだけ)
     "#{min}:#{sec} / km"
   end
 
   def pace_time
-    vdot = self.user.vdot * percent
-    vel = 29.54 + 5.000663 * vdot - 0.007546 * vdot ** 2
-    time = (1000 / vel) * self.running_distance
-    hour = (time / 60).floor.to_i
-    min = (time - hour * 60).to_i
-    sec = ((time - hour * 60 - min) * 60).to_i
+    time = (1000 / velocity) * self.running_distance  # 総ランニング時間(minを小数で)
+    hour = (time / 60).floor.to_i                     # 総ランニング時間(hourだけ)
+    min = (time - hour * 60).floor.to_i               # 総ランニング時間(minだけ)
+    sec = ((time - hour * 60 - min) * 60).to_i        # 総ランニング時間(secondだけ)
     "#{hour}:#{min}:#{sec}"
   end
 
   def calorie
-    vdot = self.user.vdot * percent
-    vel = 29.54 + 5.000663 * vdot - 0.007546 * vdot ** 2
-    time = (1000 / vel) * self.running_distance
-    mets = vdot / 3.5
-    cal = (self.user.weight.present? ? mets * self.user.weight * time / 60 * 1.05 : nil).to_i
+    time = (1000 / velocity) * self.running_distance                                            # 総ランニング時間(minを小数で)
+    mets = self.user.vdot * percent / 3.5                                                       # mets導出
+    cal = (self.user.weight.present? ? mets * self.user.weight * time / 60 * 1.05 : nil).to_i   # 消費カロリー導出
     "#{cal} kcal"
+  end
+
+  # ランニングの速度(m/min)の導出用メソッド
+  def velocity
+    vdot = self.user.vdot * percent 
+    29.54 + 5.000663 * vdot - 0.007546 * vdot ** 2
   end
 
 end

--- a/app/views/running_suggestions/new.html.slim
+++ b/app/views/running_suggestions/new.html.slim
@@ -1,2 +1,0 @@
-h1 RunningSuggestions#new
-p Find me in app/views/running_suggestions/new.html.slim

--- a/app/views/top_pages/top.html.slim
+++ b/app/views/top_pages/top.html.slim
@@ -1,4 +1,8 @@
 = link_to t('.user_infomation'), edit_user_path(@user)
 = link_to t('.running_new'), new_running_record_path
 = link_to t('.running_index'), running_records_path
-= link_to t('.training_suggestion'), new_training_suggestion_path
+
+- if @training_suggestion.blank?
+  = link_to t('.training_suggestion'), new_training_suggestion_path
+- else 
+  = link_to t('.edit_training_suggestion'), edit_training_suggestion_path(@training_suggestion)

--- a/app/views/top_pages/top.html.slim
+++ b/app/views/top_pages/top.html.slim
@@ -1,4 +1,4 @@
 = link_to t('.user_infomation'), edit_user_path(@user)
 = link_to t('.running_new'), new_running_record_path
 = link_to t('.running_index'), running_records_path
-= link_to t('.training_suggestion'), new_running_suggestion_path
+= link_to t('.training_suggestion'), new_training_suggestion_path

--- a/app/views/training_suggestions/edit.html.slim
+++ b/app/views/training_suggestions/edit.html.slim
@@ -2,7 +2,7 @@
   .row
     .mt-4.offset-lg-2
 
-      h1 トレーニングメニュー作成画面
+      h1 トレーニングメニュー編集画面
       p ランニング予定を入力してください
       = form_with model:@training_suggestion, local: true do |f|
         = render 'shared/error_messages', object: f.object

--- a/app/views/training_suggestions/new.html.slim
+++ b/app/views/training_suggestions/new.html.slim
@@ -1,0 +1,19 @@
+.container
+  .row
+    .mt-4.offset-lg-2
+
+      h1 ランニング記録入力
+      = form_with model:@training_suggestion, local: true do |f|
+        = render 'shared/error_messages', object: f.object
+        
+        .form_group 
+          = f.label t('.running_distance'), class: 'col-3'
+          = f.text_field :running_distance, class: 'form_control'
+          |  km
+        .form_group
+          = f.label t('.intensity'), class: 'col-3'
+          = f.select :intensity, RunningRecord.intensities_i18n.invert, class: 'form_control'
+
+        = f.submit t('.registration'), class: 'btn btn-primary'
+
+= link_to 'トップページ', root_path

--- a/app/views/training_suggestions/new.html.slim
+++ b/app/views/training_suggestions/new.html.slim
@@ -2,7 +2,8 @@
   .row
     .mt-4.offset-lg-2
 
-      h1 ランニング記録入力
+      h1 トレーニングメニュー作成画面
+      p ランニング予定を入力してください
       = form_with model:@training_suggestion, local: true do |f|
         = render 'shared/error_messages', object: f.object
         
@@ -13,6 +14,8 @@
         .form_group
           = f.label t('.intensity'), class: 'col-3'
           = f.select :intensity, RunningRecord.intensities_i18n.invert, class: 'form_control'
+          = link_to '#', method: :get do
+            i.fa.fa-circle-question
 
         = f.submit t('.registration'), class: 'btn btn-primary'
 

--- a/app/views/training_suggestions/show.html.slim
+++ b/app/views/training_suggestions/show.html.slim
@@ -4,13 +4,25 @@
 
       h1 トレーニングメニュー
       table.table 
-        thead 
-          tr 
-            th scope='col' day 
-            th scope='col' 走行距離
-        tbody 
-          tr 
-            td = l @training_suggestion.created_at, format: :day
-            td = @training_suggestion.running_distance
+        tr
+          th scope='col' day
+          td = l @training_suggestion.created_at, format: :day
+        tr 
+          th scope='col' 走行距離
+          td = @training_suggestion.running_distance
+        tr 
+          th scope='col' 練習強度
+          td = @training_suggestion.intensity_i18n
+        tr 
+          th scope='col' vdot
+          td = @training_suggestion.user.vdot.round(2)
+        tr 
+          th scope='col' タイム
 
+        tr 
+          th scope='col' ペース
+
+        tr
+          th scope='col' 推定消費カロリー
+        
 = link_to 'トップページ', root_path

--- a/app/views/training_suggestions/show.html.slim
+++ b/app/views/training_suggestions/show.html.slim
@@ -9,6 +9,6 @@
             th scope='col' day 
         tbody 
           tr 
-            td = @training_suggestion.created_at
+            td = l @training_suggestion.created_at, format: :day
 
 = link_to 'トップページ', root_path

--- a/app/views/training_suggestions/show.html.slim
+++ b/app/views/training_suggestions/show.html.slim
@@ -17,12 +17,13 @@
           th scope='col' vdot
           td = @training_suggestion.user.vdot.round(2)
         tr 
-          th scope='col' タイム
-
-        tr 
           th scope='col' ペース
-
+          td = @training_suggestion.pace
+        tr 
+          th scope='col' タイム
+          td = @training_suggestion.pace_time
         tr
           th scope='col' 推定消費カロリー
+          td = @training_suggestion.calorie
         
 = link_to 'トップページ', root_path

--- a/app/views/training_suggestions/show.html.slim
+++ b/app/views/training_suggestions/show.html.slim
@@ -7,8 +7,10 @@
         thead 
           tr 
             th scope='col' day 
+            th scope='col' 走行距離
         tbody 
           tr 
             td = l @training_suggestion.created_at, format: :day
+            td = @training_suggestion.running_distance
 
 = link_to 'トップページ', root_path

--- a/app/views/training_suggestions/show.html.slim
+++ b/app/views/training_suggestions/show.html.slim
@@ -1,0 +1,14 @@
+.container
+  .row
+    .mt-4.offset-lg-2
+
+      h1 トレーニングメニュー
+      table.table 
+        thead 
+          tr 
+            th scope='col' day 
+        tbody 
+          tr 
+            td = @training_suggestion.created_at
+
+= link_to 'トップページ', root_path

--- a/config/application.rb
+++ b/config/application.rb
@@ -13,6 +13,8 @@ module RunnersHigh
 
     config.i18n.default_locale = :ja
     config.i18n.load_path += Dir[Rails.root.join('config', 'locales', '**', '*.{rb,yml}').to_s]
+
+    config.time_zone = 'Tokyo'
     # Configuration for the application, engines, and railties goes here.
     #
     # These settings can be overridden in specific environments using the files

--- a/config/locales/activerecords/ja.yml
+++ b/config/locales/activerecords/ja.yml
@@ -60,3 +60,7 @@ ja:
         intensiry: 強度
         vdot: VDOT
         pace: ペース
+  
+  time:
+    formats:
+      day: '%Y/%m/%d' 

--- a/config/locales/activerecords/ja.yml
+++ b/config/locales/activerecords/ja.yml
@@ -12,6 +12,13 @@ ja:
         T: T
         I: I
         R: R
+    training_suggestion:
+      intensity:
+        E: E
+        M: M
+        T: T
+        I: I
+        R: R
         
   activerecord:
     models:

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -41,6 +41,7 @@ ja:
       running_new: ランニング記録入力
       running_index: ランニング記録一覧
       training_suggestion: トレーニング提案画面
+      edit_training_suggestion: トレーニング提案画面編集
 
   running_records:
     new:
@@ -70,3 +71,10 @@ ja:
     create:
       success: トレーニングメニューを作成しました
       fail: トレーニングメニュー作成に失敗しました
+    edit:
+      running_distance: 走行距離
+      intensity: 練習強度
+      registration: メニュー編集
+    update:
+      success: トレーニングメニューを変更しました
+      fail: トレーニングメニュー変更に失敗しました 

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -67,3 +67,6 @@ ja:
       running_distance: 走行距離
       intensity: 練習強度
       registration: メニュー作成
+    create:
+      success: トレーニングメニューを作成しました
+      fail: トレーニングメニュー作成に失敗しました

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -61,3 +61,9 @@ ja:
     update:
       success: ランニング記録を編集しました
       fail: ランニング記録の編集に失敗しました
+
+  training_suggestions:
+    new:
+      running_distance: 走行距離
+      intensity: 練習強度
+      registration: メニュー作成

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,7 @@ Rails.application.routes.draw do
   root "top_pages#top"
   resources :users, only: %i[new create edit update]
   resources :running_records, only: %i[new create edit index update destroy]
-  resources :training_suggestions, only: %i[new create]
+  resources :training_suggestions, only: %i[new create show]
 
   get 'login' => 'user_sessions#new', :as => :login
   post 'login' => "user_sessions#create"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,7 @@ Rails.application.routes.draw do
   root "top_pages#top"
   resources :users, only: %i[new create edit update]
   resources :running_records, only: %i[new create edit index update destroy]
-  resources :running_suggestions, only: %i[new]
+  resources :training_suggestions, only: %i[new create]
 
   get 'login' => 'user_sessions#new', :as => :login
   post 'login' => "user_sessions#create"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,7 @@ Rails.application.routes.draw do
   root "top_pages#top"
   resources :users, only: %i[new create edit update]
   resources :running_records, only: %i[new create edit index update destroy]
-  resources :training_suggestions, only: %i[new create show]
+  resources :training_suggestions, only: %i[new create show edit update]
 
   get 'login' => 'user_sessions#new', :as => :login
   post 'login' => "user_sessions#create"

--- a/db/migrate/20220507080327_create_training_suggestions.rb
+++ b/db/migrate/20220507080327_create_training_suggestions.rb
@@ -3,8 +3,7 @@ class CreateTrainingSuggestions < ActiveRecord::Migration[6.1]
     create_table :training_suggestions do |t|
       t.float       :distance
       t.integer     :intensity
-      t.float       :vdot
-      t.integer     :pace
+
       t.references  :user, null: false, foreign_key: true
       
       t.timestamps

--- a/db/migrate/20220507080327_create_training_suggestions.rb
+++ b/db/migrate/20220507080327_create_training_suggestions.rb
@@ -1,7 +1,7 @@
 class CreateTrainingSuggestions < ActiveRecord::Migration[6.1]
   def change
     create_table :training_suggestions do |t|
-      t.float       :distance
+      t.float       :running_distance
       t.integer     :intensity
 
       t.references  :user, null: false, foreign_key: true

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -30,8 +30,6 @@ ActiveRecord::Schema.define(version: 2022_05_07_080327) do
   create_table "training_suggestions", charset: "utf8mb4", force: :cascade do |t|
     t.float "distance"
     t.integer "intensity"
-    t.float "vdot"
-    t.integer "pace"
     t.bigint "user_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -28,7 +28,7 @@ ActiveRecord::Schema.define(version: 2022_05_07_080327) do
   end
 
   create_table "training_suggestions", charset: "utf8mb4", force: :cascade do |t|
-    t.float "distance"
+    t.float "running_distance"
     t.integer "intensity"
     t.bigint "user_id", null: false
     t.datetime "created_at", precision: 6, null: false

--- a/test/controllers/running_suggestions_controller_test.rb
+++ b/test/controllers/running_suggestions_controller_test.rb
@@ -1,8 +1,0 @@
-require "test_helper"
-
-class RunningSuggestionsControllerTest < ActionDispatch::IntegrationTest
-  test "should get new" do
-    get running_suggestions_new_url
-    assert_response :success
-  end
-end

--- a/test/controllers/training_suggestions_controller_test.rb
+++ b/test/controllers/training_suggestions_controller_test.rb
@@ -1,0 +1,8 @@
+require "test_helper"
+
+class TrainingSuggestionsControllerTest < ActionDispatch::IntegrationTest
+  test "should get new" do
+    get training_suggestions_new_url
+    assert_response :success
+  end
+end


### PR DESCRIPTION
## 概要

トレーニングメニュー提案機能の作成

- トレーニングメニュー作成画面
- 入力値(走行距離、練習強度)とuser情報を用いて、1kmあたりのペース 総ランニング時間 消費カロリーの導出メソッドの作成
- 作成後のメニュー表示画面作成
- @training_suggestionの有無によって、リンクの遷移先をトレーニング新規作成画面と編集画面で切り替えられるように条件設定

## コメント
以下の変更/追加を行う予定

- タイムの表示形式の変更 例 1:5:0⇨01:05:00
- メニュー表示画面から編集画面へのリンク追加
- 編集画面に現在のvdotなどを表示するテーブル作成
- (現状)ユーザー1人に対してメニュー1つの想定なので、2つ以上作成したら作成失敗するように設定
- user情報の目標タイムがないと作成失敗するので、エラーが出たらuser情報編集画面に遷移するようにする(flashメッセージも)