### PR TITLE
フラッシュメッセージのクラス記述変更

### DIFF
--- a/app/views/shared/_flash_message.html.slim
+++ b/app/views/shared/_flash_message.html.slim
@@ -1,3 +1,3 @@
 - flash.each do |key, value|
-  .alert.alert-#{key}
-    = value 
+  .d-flex.mb-4
+  = content_tag(:div, value, class: "alert alert-#{key}")


### PR DESCRIPTION
## 概要

flash_messageのクラスにkey(色を決定する要素)が反映されていないので、
記述方法を変更してcontent_tagを使用

