### PR TITLE
topページに月間走行距離の表示追加  user情報の有無によるエラー修正

### DIFF
--- a/app/controllers/top_pages_controller.rb
+++ b/app/controllers/top_pages_controller.rb
@@ -2,5 +2,12 @@ class TopPagesController < ApplicationController
   def top
     @user = User.find(current_user.id)
     @training_suggestion = TrainingSuggestion.find_by(user_id: current_user.id)
+    month_records = @user.running_records.order(date: :desc)
+    @month_records = []
+    month_records.each do |month_record|
+      if month_record.date.between?(Date.today - 30.day, Date.today) # 今日の日付から一週間以内の記録だけを抽出
+        @month_records << month_record
+      end
+    end
   end
 end

--- a/app/controllers/top_pages_controller.rb
+++ b/app/controllers/top_pages_controller.rb
@@ -2,6 +2,7 @@ class TopPagesController < ApplicationController
   def top
     @user = User.find(current_user.id)
     @training_suggestion = TrainingSuggestion.find_by(user_id: current_user.id)
+    
     month_records = @user.running_records.order(date: :desc)
     @month_records = []
     month_records.each do |month_record|

--- a/app/controllers/top_pages_controller.rb
+++ b/app/controllers/top_pages_controller.rb
@@ -1,6 +1,6 @@
 class TopPagesController < ApplicationController
   def top
-    @user = current_user.id
+    @user = User.find(current_user.id)
     @training_suggestion = TrainingSuggestion.find_by(user_id: current_user.id)
   end
 end

--- a/app/views/top_pages/top.html.slim
+++ b/app/views/top_pages/top.html.slim
@@ -21,9 +21,20 @@
       =link_to(edit_training_suggestions_path, class: 'danger link btn btn-outline-danger col-sm-6') do
         p.d-inline トレーニング編集
         i.fa-solid.fa-comment-dots.fa-2x.px-2 
+  
+
+  .table-responsive
+      table.table
+        tr
+          th scope='col' 月間トレーニング数
+          td = @month_records.count
+        tr
+          th scope='col' 月間走行距離
+          td = "#{@month_records.map(&:running_distance).sum} km"
+
 
   .overflow-hidden.jumbotron style='max-height: 30vh;'
       .container
         img src="/assets/jogging.jpg" class="img-fluid border rounded-3 shadow-lg mb-4" alt="画像" loading="lazy"
-
+  
 = javascript_pack_tag 'top_button', 'data-turbolinks-track': 'reload'

--- a/app/views/top_pages/top.html.slim
+++ b/app/views/top_pages/top.html.slim
@@ -1,6 +1,6 @@
 - content_for(:title, t('.top'))
 .container 
-  .row.d-grid.gap-2.d-sm-block
+  .row.d-grid.gap-2.d-sm-block.my-3
     =link_to(edit_user_path(@user), class: 'primary link btn btn-outline-primary col-sm-6') do
       p.d-inline ユーザー情報
       i.fa-solid.fa-address-card.fa-2x.px-2 
@@ -22,15 +22,15 @@
         p.d-inline トレーニング編集
         i.fa-solid.fa-comment-dots.fa-2x.px-2 
   
-
-  .table-responsive
-      table.table
-        tr
-          th scope='col' 月間トレーニング数
-          td = @month_records.count
-        tr
-          th scope='col' 月間走行距離
-          td = "#{@month_records.map(&:running_distance).sum} km"
+  .display-5.fst-italic.my-3
+    .table-responsive
+        table.table
+          tr
+            th scope='col' 月間トレーニング数
+            td = @month_records.count
+          tr
+            th scope='col' 月間走行距離
+            td = "#{@month_records.map(&:running_distance).sum} km"
 
 
   .overflow-hidden.jumbotron style='max-height: 30vh;'

--- a/app/views/training_suggestions/edit.html.slim
+++ b/app/views/training_suggestions/edit.html.slim
@@ -21,7 +21,7 @@
       .d-sm-flex.justify-content-sm-center.mb-5 
         = f.submit t('.registration'), class: 'btn btn-outline-primary btn-lg px-4 me-sm-3'
 
-      - if @training_suggestion.user.vdot
+      - if @training_suggestion.user.running_distance && @training_suggestion.user.running_hour && @training_suggestion.user.running_minute && @training_suggestion.user.running_second
         table.table
           tr
             th scope='col' vdot

--- a/app/views/training_suggestions/new.html.slim
+++ b/app/views/training_suggestions/new.html.slim
@@ -25,9 +25,9 @@
     .container
       img src="/assets/track.jpg" class="img-fluid border rounded-3 shadow-lg mb-4" alt="画像" loading="lazy"
 
-      - if @training_suggestion.user.vdot
+      - if current_user.running_distance && current_user.running_hour && current_user.running_minute && current_user.running_second
         table.table
           tr
             th scope='col' vdot
-            td = @training_suggestion.user.vdot.round(2)
+            td = current_user.vdot.round(2)
 

--- a/app/views/training_suggestions/new.html.slim
+++ b/app/views/training_suggestions/new.html.slim
@@ -25,9 +25,4 @@
     .container
       img src="/assets/track.jpg" class="img-fluid border rounded-3 shadow-lg mb-4" alt="画像" loading="lazy"
 
-      - if current_user.running_distance && current_user.running_hour && current_user.running_minute && current_user.running_second
-        table.table
-          tr
-            th scope='col' vdot
-            td = current_user.vdot.round(2)
 

--- a/app/views/users/edit.html.slim
+++ b/app/views/users/edit.html.slim
@@ -33,4 +33,8 @@
       .d-grid.gap-2.d-sm-flex.justify-content-sm-center.mb-5 
         = f.submit t('defaults.registration'), class: 'btn btn-outline-primary btn-lg px-4'
 
-    p vdot #{@user.vdot.round(2)}
+    - if @user.running_distance && @user.running_hour && @user.running_minute && @user.running_second
+      table.table
+        tr
+          th scope='col' 目標vdot
+          td = @user.vdot.round(2)    


### PR DESCRIPTION
## 概要
topページに月間走行距離の追加
- トレーニング記録から、dateが1ヶ月以内の記録だけを抽出
- 抽出された記録の数をトレーニング数とする
- 記録のうち、running_distanceをmapメソッドで取り出し、和を取ることで月間走行距離とする

user情報が不足しているとvdotメソッドを呼び出す際にエラーが発生するので、user情報の有無で条件分岐

