### PR TITLE
bundlerのversion変更

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -140,6 +140,8 @@ GEM
     nio4r (2.5.8)
     nokogiri (1.13.5-x86_64-darwin)
       racc (~> 1.4)
+    nokogiri (1.13.5-x86_64-linux)
+      racc (~> 1.4)
     oauth (0.5.8)
     oauth2 (1.4.9)
       faraday (>= 0.17.3, < 3.0)
@@ -287,6 +289,7 @@ GEM
 
 PLATFORMS
   x86_64-darwin-21
+  x86_64-linux
 
 DEPENDENCIES
   bootsnap (>= 1.4.4)


### PR DESCRIPTION
## 概要
herokuにpushを行う際に

`Failed to install gems via Bundler.`

というエラーが発生した。

`Your bundle only supports platforms ["x86_64-darwin-21"] but your local platform
remote:        is x86_64-linux. Add the current platform to the lockfile with
remote:        `bundle lock --add-platform x86_64-linux` and try again.
remote:        Bundler Output: Your bundle only supports platforms ["x86_64-darwin-21"] but your local platform
remote:        is x86_64-linux. Add the current platform to the lockfile with
remote:        `bundle lock --add-platform x86_64-linux` and try again.
`
herokuとlocalのbundlerが異なることが原因なので修正

