### PR TITLE
ストップウォッチ機能追加

### DIFF
--- a/app/javascript/jquery/stopwatch.js
+++ b/app/javascript/jquery/stopwatch.js
@@ -1,0 +1,59 @@
+var timer = document.getElementById('timer');
+var start = document.getElementById('start');
+var stop = document.getElementById('stop');
+var reset = document.getElementById('reset');
+
+var startTime;
+var elapsedTime = 0;
+var timerId;
+var timeToadd = 0;
+
+
+function timerText(){
+  var hour = Math.floor(elapsedTime / 3600000);
+  var min = Math.floor(elapsedTime / 60000);
+  var sec = Math.floor(elapsedTime % 60000 / 1000);
+  var ms = elapsedTime % 1000;
+
+  hour = ('0' + hour).slice(-1); 
+  min = ('0' + min).slice(-2); 
+  sec = ('0' + sec).slice(-2);
+  ms = ('0' + ms).slice(-2);
+
+  timer.textContent = hour + ':' + min + ':' + sec + ':' + ms;
+}
+
+
+function countUp(){
+  timerId = setTimeout(function(){
+    elapsedTime = Date.now() - startTime + timeToadd;
+    timerText()
+    //繰り返し呼び出し
+    countUp();
+  },10);
+}
+
+start.addEventListener('click',function(){
+  startTime = Date.now();
+  countUp();
+  start.disabled = true;
+  stop.disabled = false;
+  reset.disabled = true;
+});
+
+stop.addEventListener('click',function(){
+  clearTimeout(timerId);
+  timeToadd += Date.now() - startTime;
+  start.disabled = false;
+  stop.disabled = true;
+  reset.disabled = false;
+});
+
+reset.addEventListener('click',function(){
+  elapsedTime = 0;
+  timeToadd = 0;
+  timerText();
+  start.disabled = false;
+  stop.disabled = true;
+  reset.disabled = true;
+});

--- a/app/javascript/packs/stopwatch.js
+++ b/app/javascript/packs/stopwatch.js
@@ -1,0 +1,1 @@
+require('jquery/stopwatch.js')

--- a/app/views/running_records/measurement.html.slim
+++ b/app/views/running_records/measurement.html.slim
@@ -5,6 +5,16 @@
       | Start
     #stopButton.btn
       | Stop
+
+  #timer
+    | 0:00:00:00
+  input#start[type="button" value="Start"]
+  input#stop[type="button" value="Stop" disabled]
+  input#reset[type="button" value="Reset" disabled]
+
+
+
 script[async defer src="https://maps.googleapis.com/maps/api/js?key=#{ ENV['GOOGLE_MAP_API'] }&callback=initMap"]
 = javascript_pack_tag 'map', 'data-turbolinks-track': 'reload'
 = stylesheet_pack_tag 'map', media: 'all', 'data-turbolinks-track': 'reload'
+= javascript_pack_tag 'stopwatch', 'data-turbolinks-track': 'reload'

--- a/app/views/running_records/test.html.slim
+++ b/app/views/running_records/test.html.slim
@@ -1,8 +1,0 @@
-#map
-#bar
-  p.auto
-    input#autoc[type="text"]
-  p
-    a#clear[href="#"]
-      | Click here
-    |  to clear map.

--- a/app/views/running_records/text.html.slim
+++ b/app/views/running_records/text.html.slim
@@ -1,0 +1,14 @@
+#content
+  #timer
+    h2#name
+      | StopWatch
+    p#text
+      span#min
+        | 0
+      | min 
+      span#sec
+        | 00.00
+      | sec 
+    input#start[type="button" value="Start"]
+    input#stop[type="button" value="Stop" disabled]
+    input#reset[type="button" value="Reset" disabled]


### PR DESCRIPTION
## 概要

タイム測定のためのストップウォッチ追加
startで測定中に再度startを押すと、timeToAddの値が再度読み込まれてしまい、
正確な値が測定できなくなる。
例: 0の状態からstart⇨再度startを押すと0からカウントアップが始まる

これを避けるためにボタンにdisabledをつけて制限

