### PR TITLE
アプリ使い方ページの構成修正

### DIFF
--- a/app/views/top_pages/tutorial.html.slim
+++ b/app/views/top_pages/tutorial.html.slim
@@ -1,28 +1,28 @@
 .container
   .row.text-center.text-secondary
-    .col-6
+    .col-12
       h3.py-2.fw-bold トップページ
       h6 ここから各ページに遷移します。
       = image_tag "top_page.jpg", class: "img-fluid d-block mx-auto mb-4", alt: "トップ", loading: "lazy"
-    .col-6
+    .col-12
       h3.py-2.fw-bold ユーザー編集ページ
       h6 ユーザー情報を編集します。目標タイムと距離を設定します。
       = image_tag "user_edit.jpg", class: "img-fluid d-block mx-auto mb-4", alt: "ユーザー編集", loading: "lazy"
-    .col-6
+    .col-12
       h3.py-2.fw-bold トレーニングメニュー作成ページ
       h6 トレーニングメニューを作成します。
       h6 ?アイコンをクリックすると練習強度の解説が確認できます。
       h6 自身の感覚に合わせてメニューの微調整ができます。
       = image_tag "training_new.jpg", class: "img-fluid d-block mx-auto mb-4", alt: "トレーニングメニュー作成", loading: "lazy"
-    .col-6
+    .col-12
       h3.py-2.fw-bold トレーニングメニュー表示ページ
       h6 走行距離と練習強度からトレーニングメニューを表示します。
       = image_tag "training_menu.jpg", class: "img-fluid d-block mx-auto mb-4", alt: "トレーニングメニュー表示", loading: "lazy"
-    .col-6
+    .col-12
       h3.py-2.fw-bold ランニング記録作成ページ
       h6 ランニング後に記録を入力します。
       = image_tag "running_new.jpg", class: "img-fluid d-block mx-auto mb-4", alt: "ランニング記録作成", loading: "lazy"
-    .col-6
+    .col-12
       h3.py-2.fw-bold ランニング記録一覧ページ
       h6 ランニング能力を示すvdotの時系列表示
       = image_tag "running_index.jpg", class: "img-fluid d-block mx-auto mb-4", alt: "ランニング記録一覧", loading: "lazy"


### PR DESCRIPTION
## 概要

使い方ページの中の解説画像が横に並ばないよう修正
(横に2つ並ぶと見づらい)

