### PR TITLE
ランニング本数を制限するメソッドをmodelへ移動

### DIFF
--- a/app/controllers/running_records_controller.rb
+++ b/app/controllers/running_records_controller.rb
@@ -22,7 +22,7 @@ class RunningRecordsController < ApplicationController
   def create
     @running_record = current_user.running_records.build(running_record_params)
     if @running_record.save
-      @running_record.update(freq: 1) if judge_intensity(@running_record) # 強度がE/M/Tのときランニング本数は1固定
+      @running_record.freq_limit
       redirect_to running_records_path
       flash[:success] = t(".success")
     else
@@ -44,7 +44,7 @@ class RunningRecordsController < ApplicationController
 
   def update
     if @running_record.update(running_record_params)
-      @running_record.update(freq: 1) if judge_intensity(@running_record) # 強度がE/M/Tのときランニング本数は1固定
+      @running_record.freq_limit
       redirect_to running_records_path
       flash[:success] = t('.success')
     else

--- a/app/controllers/training_suggestions_controller.rb
+++ b/app/controllers/training_suggestions_controller.rb
@@ -8,7 +8,7 @@ class TrainingSuggestionsController < ApplicationController
   def create
     @training_suggestion = current_user.training_suggestions.build(training_suggestion_params)
     if @training_suggestion.save
-      @training_suggestion.update(freq: 1) if judge_intensity(@training_suggestion) # 強度がE/M/Tのときランニング本数は1固定
+      @training_suggestion.freq_limit
       redirect_to training_suggestions_path
       flash[:success] = t(".success")
     else
@@ -38,7 +38,7 @@ class TrainingSuggestionsController < ApplicationController
 
   def update
     if @training_suggestion.update(training_suggestion_params)
-      @training_suggestion.update(freq: 1) if judge_intensity(@training_suggestion) # 強度がE/M/Tのときランニング本数は1固定
+      @training_suggestion.freq_limit
       redirect_to training_suggestions_path
       flash[:success] = t('.success')
     else

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -35,5 +35,15 @@ class ApplicationRecord < ActiveRecord::Base
   def calc_calorie
     self.user.weight.present? ? mets * self.user.weight * convert_minute / 60 * 1.05 : nil
   end
+
+  # 強度がE/M/Tのときランニング本数は1固定
+  def freq_limit
+    self.update(freq: 1) if judge_intensity(self)
+  end
+
+  #強度がE//M/Tかどうか判定
+  def judge_intensity(record)
+    record.intensity == 'E'|| record.intensity == 'M'|| record.intensity == 'T'
+  end
   
 end


### PR DESCRIPTION
## 概要

ランニング本数を制限するための記述がrunning_records_controllerと
training_suggestions_controllerに2つずつ記述されていたので、
メソッド化してapplication_modelへ移動

強度がE/M/Tのとき、ランニング本数が2以上を入力しても1へと変更されることを確認済