### PR TITLE
stylesheet_pack_tagの記述追加

### DIFF
--- a/app/views/shared/_before_login.html.slim
+++ b/app/views/shared/_before_login.html.slim
@@ -14,3 +14,4 @@ header#header
       li =link_to 'login', login_path
           
     = javascript_pack_tag 'header', 'data-turbolinks-track': 'reload'
+    = stylesheet_pack_tag 'header', 'data-turbolinks-track': 'reload'

--- a/app/views/shared/_header.html.slim
+++ b/app/views/shared/_header.html.slim
@@ -21,4 +21,5 @@ header#header
       li =link_to 'logout', logout_path, method: :delete
           
     = javascript_pack_tag 'header', 'data-turbolinks-track': 'reload'
+    = stylesheet_pack_tag 'header', media: 'all', 'data-turbolinks-track': 'reload'
  


### PR DESCRIPTION
## 概要

herokuでbootstrapを適用させるため、headerにstylesheet_pack_tagの記述追加