### PR TITLE
トップページに関するi18n削除

### DIFF
--- a/app/views/shared/_before_login.html.slim
+++ b/app/views/shared/_before_login.html.slim
@@ -5,10 +5,10 @@ header#header
         h5 メニュー一覧
       .sub-menu 
         ul 
-          li = link_to 'トップページ', start_path
-          li = link_to '新規登録', new_user_path
-          li = link_to 'ログイン', login_path
-          li = link_to 'アプリの使い方', tutorial_path
+          li = link_to t('.start'), start_path
+          li = link_to t('.new_user'), new_user_path
+          li = link_to t('defaults.login'), login_path
+          li = link_to t('.tutorial'), tutorial_path
   nav 
     ul#g-navi 
       li =link_to 'login', login_path

--- a/app/views/shared/_header.html.slim
+++ b/app/views/shared/_header.html.slim
@@ -2,19 +2,19 @@ header#header
   .dropdown 
     .menu 
       .menu-title 
-        h6 メニュー一覧
+        h5 メニュー一覧
       .sub-menu 
         ul 
           -if @user
-            li = link_to 'ユーザー情報', edit_user_path(@user)
-          li = link_to 'ランニング記録入力', new_running_record_path
-          li = link_to 'ランニング記録一覧', running_records_path
+            li = link_to t('.edit_user'), edit_user_path(@user)
+          li = link_to t('.new_record'), new_running_record_path
+          li = link_to t('.index_record'), running_records_path
           li
             - if @training_suggestion.blank? 
-              = link_to 'トレーニング作成', new_training_suggestions_path
+              = link_to t('.new_training'), new_training_suggestions_path
             - else
-              = link_to 'トレーニング編集', edit_training_suggestions_path
-          li = link_to 'アプリの使い方', tutorial_path
+              = link_to t('.edit_training'), edit_training_suggestions_path
+          li = link_to t('.tutorial'), tutorial_path
   h1 Runner's High
   nav 
     ul#g-navi 

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -10,7 +10,6 @@ ja:
   users:
     new:
       new_user: 新規登録
-      top: トップページへ
     create:
       success: ユーザー登録が完了しました
       fail: ユーザー登録に失敗しました
@@ -26,7 +25,6 @@ ja:
       email: メールアドレス
       password: パスワード
       registration: ユーザー登録
-      top: トップページへ
     create:
       success: ログインしました
       fail: ログインに失敗しました
@@ -39,9 +37,6 @@ ja:
       runners_high: Runner's High
       registration: 新規登録
       login: ログイン
-      tutorial: アプリの使い方
-    top:
-      menu: メニュー
       tutorial: アプリの使い方
 
   running_records:

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -6,6 +6,20 @@ ja:
     unpermitted: 許可されていないページです
     delete: 削除
     registration: 登録
+  
+  shared:
+    before_login:
+      start: トップページ
+      new_user: 新規登録
+      tutorial: アプリの使い方
+
+    header:
+      edit_user: ユーザー情報
+      new_record: ランニング記録入力
+      index_record: ランニング記録一覧
+      new_training: トレーニング作成
+      edit_training: トレーニング編集
+      tutorial: アプリの使い方
     
   users:
     new:


### PR DESCRIPTION
## 概要

トップページの機能をヘッダーに移したことで,
トップページに関するi18nの設定が不要になったので削除

ヘッダー中の日本語をi18nファイルへ移動